### PR TITLE
Branch-A-Assertions

### DIFF
--- a/src/main/java/Butler/Butler.java
+++ b/src/main/java/Butler/Butler.java
@@ -39,6 +39,7 @@ public class Butler {
      * @param filePath the path to the file used to persist tasks
      */
     public Butler(String filePath) {
+        assert filePath != null && !filePath.isBlank() : "filePath must be non-null and non-blank";
         this.storage = new Storage(filePath);
         TaskList loaded;
         try {

--- a/src/main/java/Butler/Event.java
+++ b/src/main/java/Butler/Event.java
@@ -21,6 +21,8 @@ public class Event extends Task {
      */
     public Event(String description, LocalDateTime from, LocalDateTime to) {
         super(description);
+        assert from != null && to != null : "event times must not be null";
+        assert !to.isBefore(from) : "event end must not be before start";
         this.from = from;
         this.to = to;
     }

--- a/src/main/java/Butler/Parser.java
+++ b/src/main/java/Butler/Parser.java
@@ -63,6 +63,7 @@ public class Parser {
      * @throws ButlerException if the string is not in the expected format
      */
     public static LocalDate parseLocalDate(String s) throws ButlerException {
+        assert s != null && !s.isBlank() : "date string must be non-null and non-blank";
         try {
             return LocalDate.parse(s); // yyyy-MM-dd
         } catch (DateTimeParseException e) {

--- a/src/main/java/Butler/Storage.java
+++ b/src/main/java/Butler/Storage.java
@@ -105,6 +105,7 @@ public class Storage {
      * @param tasks the list of tasks to persist
      */
     public void save(List<Task> tasks) {
+        assert tasks != null : "tasks list to save must not be null";
         List<String> out = new ArrayList<>();
         for (Task t : tasks) {
             out.add(t.serialize());  // polymorphic, no instanceof


### PR DESCRIPTION
Several core paths relied on implicit assumptions that were not expressed in code. This change adds a small number of targeted Java assert statements to make those assumptions explicit during development.

As a step toward improving robustness, these checks document programmer invariants without replacing user-facing validation. They fail fast when run with -ea, and are no-ops otherwise.